### PR TITLE
Improved use of CancellationToken in consumer tasks

### DIFF
--- a/InMemoryEventBus/Implementation/EventBusConsumer.cs
+++ b/InMemoryEventBus/Implementation/EventBusConsumer.cs
@@ -28,7 +28,7 @@ internal sealed class InMemoryEventBusConsumer<T> : IConsumer<T>
 
     public async ValueTask Start(CancellationToken token = default)
     {
-        EnsureStoppingTokenIsCreated();
+        EnsureStoppingTokenIsCreated(token);
 
         // factory new scope so we can use it as execution context
         await using var scope = _scopeFactory.CreateAsyncScope();
@@ -49,14 +49,14 @@ internal sealed class InMemoryEventBusConsumer<T> : IConsumer<T>
         ).ConfigureAwait(false);
     }
 
-    private void EnsureStoppingTokenIsCreated()
+    private void EnsureStoppingTokenIsCreated(CancellationToken token = default)
     {
         if (_stoppingToken is not null && _stoppingToken.IsCancellationRequested == false)
         {
             _stoppingToken.Cancel();
         }
 
-        _stoppingToken = new CancellationTokenSource();
+        _stoppingToken = token.CanBeCanceled ? CancellationTokenSource.CreateLinkedTokenSource(token) : new CancellationTokenSource();
     }
 
     internal async ValueTask StartProcessing(List<IEventHandler<T>> handlers, IEventContextAccessor<T> contextAccessor)

--- a/InMemoryEventBus/Registration/Setup.cs
+++ b/InMemoryEventBus/Registration/Setup.cs
@@ -43,6 +43,7 @@ public static class Setup
     public static async Task<IServiceProvider> StartConsumers(this IServiceProvider services)
     {
         var consumers = services.GetServices<IConsumer>();
+        
         foreach (var consumer in consumers)
         {
             await consumer.Start().ConfigureAwait(false);
@@ -50,7 +51,19 @@ public static class Setup
 
         return services;
     }
+    
+    public static async Task<IServiceProvider> StartConsumers(this IServiceProvider services, CancellationToken parentToken)
+    {
+        var consumers = services.GetServices<IConsumer>();
+        
+        foreach (var consumer in consumers)
+        {
+            await consumer.Start(parentToken).ConfigureAwait(false);
+        }
 
+        return services;
+    }
+    
     public static async Task<IServiceProvider> StopConsumers(this IServiceProvider services)
     {
         var consumers = services.GetServices<IConsumer>();


### PR DESCRIPTION
Now a consumer task could be stopped using an external cancellation token.

Token param of InMemoryEventBusConsumer.Start(CancellationToken token = default) was unused.